### PR TITLE
fix: collapse entry consistently when shrinking window

### DIFF
--- a/app/stylesheets/main.scss
+++ b/app/stylesheets/main.scss
@@ -93,16 +93,26 @@ html {
   display: flex;
   align-items: center;
 
+  // Collapse on mobile
+  @media screen and (max-width: 480px) {
+    .auth-details {
+      flex-direction: column !important;
+      align-items: flex-start !important;
+    }
+  }
+
   .auth-details {
     margin-bottom: 8px;
     flex: 1;
     display: flex;
-    flex-wrap: wrap;
+    flex-direction: row;
     align-items: center;
+    justify-content: space-between;
+    min-width: 0;
 
     .auth-info {
-      flex: 1 1 auto;
       margin: 4px 0;
+      min-width: inherit;
 
       .auth-service {
         font-size: var(--sn-stylekit-font-size-h1);
@@ -115,6 +125,7 @@ html {
         font-size: var(--sn-stylekit-font-size-p);
         text-align: left;
         font-weight: normal;
+        word-wrap: break-word;
       }
     }
 
@@ -228,6 +239,7 @@ html {
   // Injected in CountdownPie.js
   // animation: opa 30s steps(1, end) infinite;
 }
+
 // Injected in CountdownPie.js
 // @keyframes rota {
 //   0% {


### PR DESCRIPTION
When shrinking the editor window the auth entries are now collapsed at consistent breakpoints.

## Demo

![tokenvault_collapse](https://user-images.githubusercontent.com/10207818/61164183-1bbb6500-a50b-11e9-96ed-7b43043e58c6.gif)

Closes sn-extensions/token-vault#11